### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,16 +12,16 @@ SMTP	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setPort             KEYWORD2
-setServer           KEYWORD2
-Subject             KEYWORD2
-setFrom             KEYWORD2
-setEmail            KEYWORD2
-setPassword         KEYWORD2
-setForGmail         KEYWORD2
-getBase64Email      KEYWORD2
-getBase64Password   KEYWORD2
-getLastResponce     KEYWORD2
-getError            KEYWORD2
-Send                KEYWORD2
-setForGmail 		KEYWORD2
+setPort	KEYWORD2
+setServer	KEYWORD2
+Subject	KEYWORD2
+setFrom	KEYWORD2
+setEmail	KEYWORD2
+setPassword	KEYWORD2
+setForGmail	KEYWORD2
+getBase64Email	KEYWORD2
+getBase64Password	KEYWORD2
+getLastResponce	KEYWORD2
+getError	KEYWORD2
+Send	KEYWORD2
+setForGmail	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords